### PR TITLE
Fixing a bug caused by the inclusion of the C avcodec library in this C++ program.

### DIFF
--- a/src/framesconverter.cpp
+++ b/src/framesconverter.cpp
@@ -25,6 +25,10 @@
 #ifdef __linux__
 
 extern "C" {
+#ifndef __STDC_CONSTANT_MACROS
+# define __STDC_CONSTANT_MACROS
+#endif
+
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>


### PR DESCRIPTION
It fixes this:
$ make
[ 11%] Built target qtInterfaces_lib
[ 17%] Building CXX object src/CMakeFiles/AndroidUsbCameraStaticLib.dir/framesconverter.cpp.o
In file included from /usr/include/libavutil/avutil.h:81,
                 from /usr/include/libavcodec/avcodec.h:30,
                 from /home/brian/Stage/AndroidUsbCamera/src/framesconverter.cpp:28:
/usr/include/libavutil/common.h: In function ‘int32_t av_clipl_int32(int64_t)’:
/usr/include/libavutil/common.h:154: error: ‘UINT64_C’ was not declared in this scope
make[2]: **\* [src/CMakeFiles/AndroidUsbCameraStaticLib.dir/framesconverter.cpp.o] Error 1
make[1]: **\* [src/CMakeFiles/AndroidUsbCameraStaticLib.dir/all] Error 2
make: **\* [all] Error 2
